### PR TITLE
Chaing minimum stake age

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,7 @@ bool fCheckBlockIndex = false;
 unsigned int nCoinCacheSize = 5000;
 bool fAlerts = DEFAULT_ALERTS;
 
-unsigned int nStakeMinAge = 60 * 60;
+unsigned int nStakeMinAge = 12 * 60 * 60;  //12hours
 int64_t nReserveBalance = 0;
 
 /** Fees smaller than this (in duffs) are considered zero fee (for relaying and mining)


### PR DESCRIPTION
Changed minimum coin age for staking to 12 hours.